### PR TITLE
Send scraping errors to Slack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,3 +93,5 @@ gem "blueprinter"
 # Used to store settings for auth keys
 gem "rails-settings-cached"
 
+# For creating web requests
+gem "typhoeus"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,6 +323,7 @@ DEPENDENCIES
   sqlite3 (~> 1.4)
   tmuxinator
   turbolinks (~> 5)
+  typhoeus
   tzinfo-data
   web-console (>= 4.1.0)
   webdrivers

--- a/app/controllers/scraper_controller.rb
+++ b/app/controllers/scraper_controller.rb
@@ -5,6 +5,7 @@ class ScraperController < ApplicationController
   def scrape
     url = params["url"]
 
+    # jard
     if url.nil?
       render json: { error: "Url not given" }, status: 400
       return
@@ -13,7 +14,7 @@ class ScraperController < ApplicationController
     begin
       post = InstagramMediaSource.extract(url)
     rescue MediaSource::HostError => e
-      render json: { error: "Url must be a proper Instagram url"}, status: 400
+      render json: { error: "Url must be a proper Instagram url" }, status: 400
       return
     end
 

--- a/app/media_sources/concerns/slack.rb
+++ b/app/media_sources/concerns/slack.rb
@@ -18,5 +18,3 @@ module Slack
     end
   end
 end
-
-# curl -X POST -H 'Content-type: application/json' --data '{"text":"Hello, World!"}' https://hooks.slack.com/services/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

--- a/app/media_sources/concerns/slack.rb
+++ b/app/media_sources/concerns/slack.rb
@@ -1,0 +1,22 @@
+require "active_support/concern"
+
+module Slack
+  extend ActiveSupport::Concern
+  included do
+    def self.send_message_to_slack(message)
+      # Check if the environment variable is set, if not, bail out
+      return if Figaro.env.SLACK_ERROR_WEBHOOK_URL.nil?
+
+      request = Typhoeus::Request.new(
+        Figaro.env.SLACK_ERROR_WEBHOOK_URL,
+        method: :post,
+        body: { text: message }.to_json,
+        headers: { "Content-Type": "application/json" }
+      )
+
+      request.run
+    end
+  end
+end
+
+# curl -X POST -H 'Content-type: application/json' --data '{"text":"Hello, World!"}' https://hooks.slack.com/services/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

--- a/app/media_sources/instagram_media_source.rb
+++ b/app/media_sources/instagram_media_source.rb
@@ -23,6 +23,7 @@ class InstagramMediaSource < MediaSource
   rescue StandardError => error
     error_message = "*Zorki Error 📸:*\n`#{error.class.name}`\n> #{error.message}\n*URL Submitted:* #{url}"
     self.send_message_to_slack(error_message)
+    raise
   end
 
   # Initialize the object and capture the screenshot automatically.

--- a/app/media_sources/instagram_media_source.rb
+++ b/app/media_sources/instagram_media_source.rb
@@ -1,4 +1,6 @@
 class InstagramMediaSource < MediaSource
+  include Slack
+
   attr_reader(:url)
 
   # Limit all urls to the host below
@@ -18,6 +20,9 @@ class InstagramMediaSource < MediaSource
   def self.extract(url, save_screenshot = false)
     object = self.new(url)
     object.retrieve_instagram_post
+  rescue StandardError => error
+    error_message = "*Zorki Error 📸:*\n`#{error.class.name}`\n> #{error.message}\n*URL Submitted:* #{url}"
+    self.send_message_to_slack(error_message)
   end
 
   # Initialize the object and capture the screenshot automatically.

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -1,1 +1,9 @@
 Figaro.require_keys("INSTAGRAM_USER_NAME", "INSTAGRAM_PASSWORD", "secret_key_base")
+
+# Other optional environment variables:
+#
+# SLACK_ERROR_WEBHOOK_URL
+# ---
+# When set this will enable the reporting of scraping errors to a Slack channel.
+# To set up you can create an "Incoming Webhook" at https://api.slack.com/apps
+# and put the url in this environment variable.

--- a/test/media_sources/instagram_media_source_test.rb
+++ b/test/media_sources/instagram_media_source_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class InstagramMediaSourceTest < ActiveSupport::TestCase
+  def setup; end
+
+  test "can send error via slack notification" do
+    InstagramMediaSource.send_message_to_slack("Test message of some sort")
+  end
+
+  test "can send error is there is an error while scraping" do
+    InstagramMediaSource.extract("https://www.example.com")
+  end
+
+  test "can extract post without an error being posted to Slack" do
+    InstagramMediaSource.extract("https://www.instagram.com/p/CS17kK3n5-J/")
+  end
+end

--- a/test/media_sources/instagram_media_source_test.rb
+++ b/test/media_sources/instagram_media_source_test.rb
@@ -8,7 +8,9 @@ class InstagramMediaSourceTest < ActiveSupport::TestCase
   end
 
   test "can send error is there is an error while scraping" do
-    InstagramMediaSource.extract("https://www.example.com")
+    assert_raise(MediaSource::HostError) do
+      InstagramMediaSource.extract("https://www.example.com")
+    end
   end
 
   test "can extract post without an error being posted to Slack" do


### PR DESCRIPTION
This allows any errors created while scraping to be sent to a Slack
channel.

To enable set the `SLACK_ERROR_WEBHOOK_URL` environment variable to
a Slack webhook.

To test:
1. `bundle install`
1. Set the `SLACK_ERROR_WEBHOOK_URL` environment variable
1. `rails t` and pay attention to the channel you created during the
   webhook setup`